### PR TITLE
Update Bevy version `0.13.2` -> `0.15.1`

### DIFF
--- a/third_person_beginner/tutorial_1/Cargo.toml
+++ b/third_person_beginner/tutorial_1/Cargo.toml
@@ -7,4 +7,3 @@ edition = "2021"
 
 [dependencies]
 bevy = "0.15.1"
-bevy_color = "0.15.2"

--- a/third_person_beginner/tutorial_1/Cargo.toml
+++ b/third_person_beginner/tutorial_1/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = "0.13.2"
+bevy = "0.15.1"

--- a/third_person_beginner/tutorial_1/Cargo.toml
+++ b/third_person_beginner/tutorial_1/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 
 [dependencies]
 bevy = "0.15.1"
+bevy_color = "0.15.2"

--- a/third_person_beginner/tutorial_1/src/main.rs
+++ b/third_person_beginner/tutorial_1/src/main.rs
@@ -14,10 +14,11 @@ fn main() {
 }
 
 fn spawn_camera(mut commands: Commands) {
-    let camera = Camera3dBundle {
-        transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..default()
-    };
+    let camera = (
+        Camera3d::default(),
+        Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+        );
+
     commands.spawn(camera);
 }
 
@@ -26,11 +27,10 @@ fn spawn_floor(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    let floor = PbrBundle {
-        mesh: Mesh3d(meshes.add(Mesh::from(Plane3d::default().mesh().size(15.0, 15.0)))),
-        material: MeshMaterial3d(materials.add(COLOR_DARK_GREEN)),
-        ..default()
-    };
+    let floor = (
+        Mesh3d(meshes.add(Mesh::from(Plane3d::default().mesh().size(15.0, 15.0)))),
+        MeshMaterial3d(materials.add(COLOR_DARK_GREEN)),
+    );
 
     commands.spawn(floor);
 }
@@ -40,25 +40,23 @@ fn spawn_player(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    let player = PbrBundle {
-        mesh: Mesh3d(meshes.add(Cuboid::new(1.0, 1.0, 1.0))),
-        material: MeshMaterial3d(materials.add(COLOR_BLUE)),
-        transform: Transform::from_xyz(0.0, 0.5, 0.0),
-        ..default()
-    };
+    let player = (
+        Mesh3d(meshes.add(Cuboid::new(1.0, 1.0, 1.0))),
+        MeshMaterial3d(materials.add(COLOR_BLUE)),
+        Transform::from_xyz(0.0, 0.5, 0.0),
+    );
 
     commands.spawn(player);
 }
 
 fn spawn_light(mut commands: Commands) {
-    let light = PointLightBundle {
-        point_light: PointLight {
+    let light = (
+        PointLight {
             intensity: 2000.0 * 1000.0,
             ..default()
         },
-        transform: Transform::from_xyz(0.0, 5.0, 0.0),
-        ..default()
-    };
+        Transform::from_xyz(0.0, 5.0, 0.0),
+    );
 
     commands.spawn(light);
 }

--- a/third_person_beginner/tutorial_1/src/main.rs
+++ b/third_person_beginner/tutorial_1/src/main.rs
@@ -1,7 +1,8 @@
 use bevy::{prelude::*, DefaultPlugins};
 
-const COLOR_DARK_GREEN: Color = Color::rgb(0.0, 0.5, 0.0);
-const COLOR_BLUE: Color = Color::rgb(0.0, 0.0, 1.0);
+use bevy_color::palettes::css::{BLUE, DARK_GREEN};
+const COLOR_DARK_GREEN: Color = Color::Srgba(DARK_GREEN);
+const COLOR_BLUE: Color = Color::Srgba(BLUE);
 
 fn main() {
     App::new()

--- a/third_person_beginner/tutorial_1/src/main.rs
+++ b/third_person_beginner/tutorial_1/src/main.rs
@@ -18,7 +18,7 @@ fn spawn_camera(mut commands: Commands) {
     let camera = (
         Camera3d::default(),
         Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
-        );
+    );
 
     commands.spawn(camera);
 }

--- a/third_person_beginner/tutorial_1/src/main.rs
+++ b/third_person_beginner/tutorial_1/src/main.rs
@@ -27,8 +27,8 @@ fn spawn_floor(
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
     let floor = PbrBundle {
-        mesh: meshes.add(Mesh::from(Plane3d::default().mesh().size(15.0, 15.0))),
-        material: materials.add(COLOR_DARK_GREEN),
+        mesh: Mesh3d(meshes.add(Mesh::from(Plane3d::default().mesh().size(15.0, 15.0)))),
+        material: MeshMaterial3d(materials.add(COLOR_DARK_GREEN)),
         ..default()
     };
 
@@ -41,8 +41,8 @@ fn spawn_player(
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
     let player = PbrBundle {
-        mesh: meshes.add(Cuboid::new(1.0, 1.0, 1.0)),
-        material: materials.add(COLOR_BLUE),
+        mesh: Mesh3d(meshes.add(Cuboid::new(1.0, 1.0, 1.0))),
+        material: MeshMaterial3d(materials.add(COLOR_BLUE)),
         transform: Transform::from_xyz(0.0, 0.5, 0.0),
         ..default()
     };

--- a/third_person_beginner/tutorial_1/src/main.rs
+++ b/third_person_beginner/tutorial_1/src/main.rs
@@ -1,5 +1,8 @@
 use bevy::{prelude::*, DefaultPlugins};
 
+const COLOR_DARK_GREEN: Color = Color::rgb(0.0, 0.5, 0.0);
+const COLOR_BLUE: Color = Color::rgb(0.0, 0.0, 1.0);
+
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
@@ -25,7 +28,7 @@ fn spawn_floor(
 ) {
     let floor = PbrBundle {
         mesh: meshes.add(Mesh::from(Plane3d::default().mesh().size(15.0, 15.0))),
-        material: materials.add(Color::DARK_GREEN),
+        material: materials.add(COLOR_DARK_GREEN),
         ..default()
     };
 
@@ -39,7 +42,7 @@ fn spawn_player(
 ) {
     let player = PbrBundle {
         mesh: meshes.add(Cuboid::new(1.0, 1.0, 1.0)),
-        material: materials.add(Color::BLUE),
+        material: materials.add(COLOR_BLUE),
         transform: Transform::from_xyz(0.0, 0.5, 0.0),
         ..default()
     };

--- a/third_person_beginner/tutorial_1/src/main.rs
+++ b/third_person_beginner/tutorial_1/src/main.rs
@@ -1,8 +1,8 @@
 use bevy::{prelude::*, DefaultPlugins};
+use bevy::color::palettes::css;
 
-use bevy_color::palettes::css::{BLUE, DARK_GREEN};
-const COLOR_DARK_GREEN: Color = Color::Srgba(DARK_GREEN);
-const COLOR_BLUE: Color = Color::Srgba(BLUE);
+const COLOR_DARK_GREEN: Color = Color::Srgba(css::DARK_GREEN);
+const COLOR_BLUE: Color = Color::Srgba(css::BLUE);
 
 fn main() {
     App::new()

--- a/third_person_beginner/tutorial_2/Cargo.toml
+++ b/third_person_beginner/tutorial_2/Cargo.toml
@@ -7,4 +7,3 @@ edition = "2021"
 
 [dependencies]
 bevy = "0.15.1"
-bevy_color = "0.15.2"

--- a/third_person_beginner/tutorial_2/Cargo.toml
+++ b/third_person_beginner/tutorial_2/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "tutorial_3"
+name = "tutorial_2"
 version = "0.1.0"
 edition = "2021"
 

--- a/third_person_beginner/tutorial_2/Cargo.toml
+++ b/third_person_beginner/tutorial_2/Cargo.toml
@@ -6,4 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = "0.13.2"
+bevy = "0.15.1"
+bevy_color = "0.15.2"

--- a/third_person_beginner/tutorial_2/src/camera.rs
+++ b/third_person_beginner/tutorial_2/src/camera.rs
@@ -9,9 +9,9 @@ impl Plugin for CameraPlugin {
 }
 
 fn spawn_camera(mut commands: Commands) {
-    let camera = Camera3dBundle {
-        transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..default()
-    };
+    let camera = (
+        Camera3d::default(),
+        Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+    );
     commands.spawn(camera);
 }

--- a/third_person_beginner/tutorial_2/src/player.rs
+++ b/third_person_beginner/tutorial_2/src/player.rs
@@ -1,5 +1,8 @@
 use bevy::prelude::*;
 
+use bevy_color::palettes::css::BLUE;
+const COLOR_BLUE: Color = Color::Srgba(BLUE);
+
 pub struct PlayerPlugin;
 
 impl Plugin for PlayerPlugin {
@@ -13,12 +16,11 @@ fn spawn_player(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    let player = PbrBundle {
-        mesh: meshes.add(Cuboid::new(1.0, 1.0, 1.0)),
-        material: materials.add(Color::BLUE),
-        transform: Transform::from_xyz(0.0, 0.5, 0.0),
-        ..default()
-    };
+    let player = (
+        Mesh3d(meshes.add(Cuboid::new(1.0, 1.0, 1.0))),
+        MeshMaterial3d(materials.add(COLOR_BLUE)),
+        Transform::from_xyz(0.0, 0.5, 0.0),
+    );
 
     commands.spawn(player);
 }

--- a/third_person_beginner/tutorial_2/src/player.rs
+++ b/third_person_beginner/tutorial_2/src/player.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
 
-use bevy_color::palettes::css::BLUE;
-const COLOR_BLUE: Color = Color::Srgba(BLUE);
+use bevy::color::palettes::css;
+const COLOR_BLUE: Color = Color::Srgba(css::BLUE);
 
 pub struct PlayerPlugin;
 

--- a/third_person_beginner/tutorial_2/src/world.rs
+++ b/third_person_beginner/tutorial_2/src/world.rs
@@ -1,5 +1,8 @@
 use bevy::prelude::*;
 
+use bevy_color::palettes::css::DARK_GREEN;
+const COLOR_DARK_GREEN: Color = Color::Srgba(DARK_GREEN);
+
 pub struct WorldPlugin;
 
 impl Plugin for WorldPlugin {
@@ -13,24 +16,22 @@ fn spawn_floor(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    let floor = PbrBundle {
-        mesh: meshes.add(Mesh::from(Plane3d::default().mesh().size(15.0, 15.0))),
-        material: materials.add(Color::DARK_GREEN),
-        ..default()
-    };
+    let floor = (
+        Mesh3d(meshes.add(Mesh::from(Plane3d::default().mesh().size(15.0, 15.0)))),
+        MeshMaterial3d(materials.add(COLOR_DARK_GREEN)),
+    );
 
     commands.spawn(floor);
 }
 
 fn spawn_light(mut commands: Commands) {
-    let light = PointLightBundle {
-        point_light: PointLight {
+    let light = (
+        PointLight {
             intensity: 2000.0 * 1000.0,
             ..default()
         },
-        transform: Transform::from_xyz(0.0, 5.0, 0.0),
-        ..default()
-    };
+        Transform::from_xyz(0.0, 5.0, 0.0),
+    );
 
     commands.spawn(light);
 }

--- a/third_person_beginner/tutorial_2/src/world.rs
+++ b/third_person_beginner/tutorial_2/src/world.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
 
-use bevy_color::palettes::css::DARK_GREEN;
-const COLOR_DARK_GREEN: Color = Color::Srgba(DARK_GREEN);
+use bevy::color::palettes::css;
+const COLOR_DARK_GREEN: Color = Color::Srgba(css::DARK_GREEN);
 
 pub struct WorldPlugin;
 

--- a/third_person_beginner/tutorial_3/Cargo.toml
+++ b/third_person_beginner/tutorial_3/Cargo.toml
@@ -7,4 +7,3 @@ edition = "2021"
 
 [dependencies]
 bevy = "0.15.1"
-bevy_color = "0.15.2"

--- a/third_person_beginner/tutorial_3/Cargo.toml
+++ b/third_person_beginner/tutorial_3/Cargo.toml
@@ -6,4 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = "0.13.2"
+bevy = "0.15.1"
+bevy_color = "0.15.2"

--- a/third_person_beginner/tutorial_3/src/camera.rs
+++ b/third_person_beginner/tutorial_3/src/camera.rs
@@ -9,9 +9,9 @@ impl Plugin for CameraPlugin {
 }
 
 fn spawn_camera(mut commands: Commands) {
-    let camera = Camera3dBundle {
-        transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..default()
-    };
+    let camera = (
+        Camera3d::default(),
+        Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+    );
     commands.spawn(camera);
 }

--- a/third_person_beginner/tutorial_3/src/player.rs
+++ b/third_person_beginner/tutorial_3/src/player.rs
@@ -45,7 +45,7 @@ fn player_movement(
     for (mut player_transform, player_speed) in player_q.iter_mut() {
         let cam = match cam_q.get_single() {
             Ok(c) => c,
-            Err(e) => Err(format!("Error retrieving camera: {}", e)).unwrap(),
+            Err(e) => panic!("Error retrieving camera: {}", e),
         };
 
         let mut direction = Vec3::ZERO;

--- a/third_person_beginner/tutorial_3/src/player.rs
+++ b/third_person_beginner/tutorial_3/src/player.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
 
-use bevy_color::palettes::css::BLUE;
-const COLOR_BLUE: Color = Color::Srgba(BLUE);
+use bevy::color::palettes::css;
+const COLOR_BLUE: Color = Color::Srgba(css::BLUE);
 
 pub struct PlayerPlugin;
 

--- a/third_person_beginner/tutorial_3/src/player.rs
+++ b/third_person_beginner/tutorial_3/src/player.rs
@@ -1,5 +1,8 @@
 use bevy::prelude::*;
 
+use bevy_color::palettes::css::BLUE;
+const COLOR_BLUE: Color = Color::Srgba(BLUE);
+
 pub struct PlayerPlugin;
 
 impl Plugin for PlayerPlugin {
@@ -21,12 +24,11 @@ fn spawn_player(
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
     let player = (
-        PbrBundle {
-            mesh: meshes.add(Cuboid::new(1.0, 1.0, 1.0)),
-            material: materials.add(Color::BLUE),
-            transform: Transform::from_xyz(0.0, 0.5, 0.0),
-            ..default()
-        },
+        (
+            Mesh3d(meshes.add(Cuboid::new(1.0, 1.0, 1.0))),
+            MeshMaterial3d(materials.add(COLOR_BLUE)),
+            Transform::from_xyz(0.0, 0.5, 0.0),
+        ),
         Player,
         Speed(2.5),
     );
@@ -69,7 +71,7 @@ fn player_movement(
         }
 
         direction.y = 0.0;
-        let movement = direction.normalize_or_zero() * player_speed.0 * time.delta_seconds();
+        let movement = direction.normalize_or_zero() * player_speed.0 * time.delta_secs();
         player_transform.translation += movement;
     }
 }

--- a/third_person_beginner/tutorial_3/src/world.rs
+++ b/third_person_beginner/tutorial_3/src/world.rs
@@ -1,5 +1,8 @@
 use bevy::prelude::*;
 
+use bevy_color::palettes::css::DARK_GREEN;
+const COLOR_DARK_GREEN: Color = Color::Srgba(DARK_GREEN);
+
 pub struct WorldPlugin;
 
 impl Plugin for WorldPlugin {
@@ -13,24 +16,22 @@ fn spawn_floor(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    let floor = PbrBundle {
-        mesh: meshes.add(Mesh::from(Plane3d::default().mesh().size(15.0, 15.0))),
-        material: materials.add(Color::DARK_GREEN),
-        ..default()
-    };
+    let floor = (
+        Mesh3d(meshes.add(Mesh::from(Plane3d::default().mesh().size(15.0, 15.0)))),
+        MeshMaterial3d(materials.add(COLOR_DARK_GREEN)),
+    );
 
     commands.spawn(floor);
 }
 
 fn spawn_light(mut commands: Commands) {
-    let light = PointLightBundle {
-        point_light: PointLight {
+    let light = (
+        PointLight {
             intensity: 2000.0 * 1000.0,
             ..default()
         },
-        transform: Transform::from_xyz(0.0, 5.0, 0.0),
-        ..default()
-    };
+        Transform::from_xyz(0.0, 5.0, 0.0),
+    );
 
     commands.spawn(light);
 }

--- a/third_person_beginner/tutorial_3/src/world.rs
+++ b/third_person_beginner/tutorial_3/src/world.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
 
-use bevy_color::palettes::css::DARK_GREEN;
-const COLOR_DARK_GREEN: Color = Color::Srgba(DARK_GREEN);
+use bevy::color::palettes::css;
+const COLOR_DARK_GREEN: Color = Color::Srgba(css::DARK_GREEN);
 
 pub struct WorldPlugin;
 

--- a/third_person_beginner/tutorial_4/Cargo.toml
+++ b/third_person_beginner/tutorial_4/Cargo.toml
@@ -6,5 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = "0.13.2"
-bevy_third_person_camera = "0.1.10"
+bevy = "0.15.1"
+bevy_color = "0.15.2"
+bevy_third_person_camera = "0.2.0"

--- a/third_person_beginner/tutorial_4/Cargo.toml
+++ b/third_person_beginner/tutorial_4/Cargo.toml
@@ -7,5 +7,4 @@ edition = "2021"
 
 [dependencies]
 bevy = "0.15.1"
-bevy_color = "0.15.2"
 bevy_third_person_camera = "0.2.0"

--- a/third_person_beginner/tutorial_4/src/camera.rs
+++ b/third_person_beginner/tutorial_4/src/camera.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use bevy_third_person_camera::{camera::Zoom, ThirdPersonCamera};
+use bevy_third_person_camera::{ThirdPersonCamera, Zoom};
 
 pub struct CameraPlugin;
 
@@ -11,10 +11,10 @@ impl Plugin for CameraPlugin {
 
 fn spawn_camera(mut commands: Commands) {
     let camera = (
-        Camera3dBundle {
-            transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
-            ..default()
-        },
+        (
+            Camera3d::default(),
+            Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+        ),
         ThirdPersonCamera {
             zoom: Zoom::new(3.0, 8.0),
             ..default()

--- a/third_person_beginner/tutorial_4/src/player.rs
+++ b/third_person_beginner/tutorial_4/src/player.rs
@@ -1,6 +1,9 @@
 use bevy::prelude::*;
 use bevy_third_person_camera::ThirdPersonCameraTarget;
 
+use bevy_color::palettes::css::BLUE;
+const COLOR_BLUE: Color = Color::Srgba(BLUE);
+
 pub struct PlayerPlugin;
 
 impl Plugin for PlayerPlugin {
@@ -22,12 +25,11 @@ fn spawn_player(
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
     let player = (
-        PbrBundle {
-            mesh: meshes.add(Cuboid::new(1.0, 1.0, 1.0)),
-            material: materials.add(Color::BLUE),
-            transform: Transform::from_xyz(0.0, 0.5, 0.0),
-            ..default()
-        },
+        (
+            Mesh3d(meshes.add(Cuboid::new(1.0, 1.0, 1.0))),
+            MeshMaterial3d(materials.add(COLOR_BLUE)),
+            Transform::from_xyz(0.0, 0.5, 0.0),
+        ),
         Player,
         ThirdPersonCameraTarget,
         Speed(2.5),
@@ -45,7 +47,7 @@ fn player_movement(
     for (mut player_transform, player_speed) in player_q.iter_mut() {
         let cam = match cam_q.get_single() {
             Ok(c) => c,
-            Err(e) => Err(format!("Error retrieving camera: {}", e)).unwrap(),
+            Err(e) => panic!("Error retrieving camera: {}", e),
         };
 
         let mut direction = Vec3::ZERO;
@@ -71,7 +73,7 @@ fn player_movement(
         }
 
         direction.y = 0.0;
-        let movement = direction.normalize_or_zero() * player_speed.0 * time.delta_seconds();
+        let movement = direction.normalize_or_zero() * player_speed.0 * time.delta_secs();
         player_transform.translation += movement;
     }
 }

--- a/third_person_beginner/tutorial_4/src/player.rs
+++ b/third_person_beginner/tutorial_4/src/player.rs
@@ -1,8 +1,8 @@
 use bevy::prelude::*;
 use bevy_third_person_camera::ThirdPersonCameraTarget;
 
-use bevy_color::palettes::css::BLUE;
-const COLOR_BLUE: Color = Color::Srgba(BLUE);
+use bevy::color::palettes::css;
+const COLOR_BLUE: Color = Color::Srgba(css::BLUE);
 
 pub struct PlayerPlugin;
 

--- a/third_person_beginner/tutorial_4/src/world.rs
+++ b/third_person_beginner/tutorial_4/src/world.rs
@@ -1,5 +1,8 @@
 use bevy::prelude::*;
 
+use bevy_color::palettes::css::DARK_GREEN;
+const COLOR_DARK_GREEN: Color = Color::Srgba(DARK_GREEN);
+
 pub struct WorldPlugin;
 
 impl Plugin for WorldPlugin {
@@ -13,24 +16,22 @@ fn spawn_floor(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    let floor = PbrBundle {
-        mesh: meshes.add(Mesh::from(Plane3d::default().mesh().size(15.0, 15.0))),
-        material: materials.add(Color::DARK_GREEN),
-        ..default()
-    };
+    let floor = (
+        Mesh3d(meshes.add(Mesh::from(Plane3d::default().mesh().size(15.0, 15.0)))),
+        MeshMaterial3d(materials.add(COLOR_DARK_GREEN)),
+    );
 
     commands.spawn(floor);
 }
 
 fn spawn_light(mut commands: Commands) {
-    let light = PointLightBundle {
-        point_light: PointLight {
+    let light = (
+        PointLight {
             intensity: 2000.0 * 1000.0,
             ..default()
         },
-        transform: Transform::from_xyz(0.0, 5.0, 0.0),
-        ..default()
-    };
+        Transform::from_xyz(0.0, 5.0, 0.0),
+    );
 
     commands.spawn(light);
 }

--- a/third_person_beginner/tutorial_4/src/world.rs
+++ b/third_person_beginner/tutorial_4/src/world.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
 
-use bevy_color::palettes::css::DARK_GREEN;
-const COLOR_DARK_GREEN: Color = Color::Srgba(DARK_GREEN);
+use bevy::color::palettes::css;
+const COLOR_DARK_GREEN: Color = Color::Srgba(css::DARK_GREEN);
 
 pub struct WorldPlugin;
 

--- a/third_person_beginner/tutorial_5/Cargo.toml
+++ b/third_person_beginner/tutorial_5/Cargo.toml
@@ -6,5 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = "0.13.2"
-bevy_third_person_camera = "0.1.10"
+bevy = "0.15.1"
+bevy_color = "0.15.2"
+bevy_third_person_camera = "0.2.0"

--- a/third_person_beginner/tutorial_5/Cargo.toml
+++ b/third_person_beginner/tutorial_5/Cargo.toml
@@ -7,5 +7,4 @@ edition = "2021"
 
 [dependencies]
 bevy = "0.15.1"
-bevy_color = "0.15.2"
 bevy_third_person_camera = "0.2.0"

--- a/third_person_beginner/tutorial_5/src/camera.rs
+++ b/third_person_beginner/tutorial_5/src/camera.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use bevy_third_person_camera::{camera::Zoom, ThirdPersonCamera};
+use bevy_third_person_camera::{ThirdPersonCamera, Zoom};
 
 pub struct CameraPlugin;
 
@@ -11,10 +11,10 @@ impl Plugin for CameraPlugin {
 
 fn spawn_camera(mut commands: Commands) {
     let camera = (
-        Camera3dBundle {
-            transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
-            ..default()
-        },
+        (
+            Camera3d::default(),
+            Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+        ),
         ThirdPersonCamera {
             zoom: Zoom::new(3.0, 8.0),
             ..default()

--- a/third_person_beginner/tutorial_5/src/player.rs
+++ b/third_person_beginner/tutorial_5/src/player.rs
@@ -17,14 +17,13 @@ struct Player;
 struct Speed(f32);
 
 fn spawn_player(mut commands: Commands, assets: Res<AssetServer>) {
-    let flashlight = SpotLightBundle::default();
+    let flashlight = SpotLight::default();
 
     let player = (
-        SceneBundle {
-            scene: assets.load("Player.gltf#Scene0"),
-            transform: Transform::from_xyz(0.0, 0.5, 0.0),
-            ..default()
-        },
+        (
+            SceneRoot(assets.load("Player.gltf#Scene0")),
+            Transform::from_xyz(0.0, 0.5, 0.0),
+        ),
         Player,
         ThirdPersonCameraTarget,
         Speed(2.5),
@@ -44,7 +43,7 @@ fn player_movement(
     for (mut player_transform, player_speed) in player_q.iter_mut() {
         let cam = match cam_q.get_single() {
             Ok(c) => c,
-            Err(e) => Err(format!("Error retrieving camera: {}", e)).unwrap(),
+            Err(e) => panic!("Error retrieving camera: {}", e),
         };
 
         let mut direction = Vec3::ZERO;
@@ -70,7 +69,7 @@ fn player_movement(
         }
 
         direction.y = 0.0;
-        let movement = direction.normalize_or_zero() * player_speed.0 * time.delta_seconds();
+        let movement = direction.normalize_or_zero() * player_speed.0 * time.delta_secs();
         player_transform.translation += movement;
 
         // rotate player to face direction he is currently moving

--- a/third_person_beginner/tutorial_5/src/world.rs
+++ b/third_person_beginner/tutorial_5/src/world.rs
@@ -1,5 +1,8 @@
 use bevy::prelude::*;
 
+use bevy_color::palettes::css::DARK_GREEN;
+const COLOR_DARK_GREEN: Color = Color::Srgba(DARK_GREEN);
+
 pub struct WorldPlugin;
 
 impl Plugin for WorldPlugin {
@@ -13,24 +16,22 @@ fn spawn_floor(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    let floor = PbrBundle {
-        mesh: meshes.add(Mesh::from(Plane3d::default().mesh().size(15.0, 15.0))),
-        material: materials.add(Color::DARK_GREEN),
-        ..default()
-    };
+    let floor = (
+        Mesh3d(meshes.add(Mesh::from(Plane3d::default().mesh().size(15.0, 15.0)))),
+        MeshMaterial3d(materials.add(COLOR_DARK_GREEN)),
+    );
 
     commands.spawn(floor);
 }
 
 fn spawn_light(mut commands: Commands) {
-    let light = PointLightBundle {
-        point_light: PointLight {
+    let light = (
+        PointLight {
             intensity: 2000.0 * 1000.0,
             ..default()
         },
-        transform: Transform::from_xyz(0.0, 5.0, 0.0),
-        ..default()
-    };
+        Transform::from_xyz(0.0, 5.0, 0.0),
+    );
 
     commands.spawn(light);
 }

--- a/third_person_beginner/tutorial_5/src/world.rs
+++ b/third_person_beginner/tutorial_5/src/world.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
 
-use bevy_color::palettes::css::DARK_GREEN;
-const COLOR_DARK_GREEN: Color = Color::Srgba(DARK_GREEN);
+use bevy::color::palettes::css;
+const COLOR_DARK_GREEN: Color = Color::Srgba(css::DARK_GREEN);
 
 pub struct WorldPlugin;
 

--- a/third_person_beginner/tutorial_6/Cargo.toml
+++ b/third_person_beginner/tutorial_6/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = "0.13.2"
-bevy-inspector-egui = "0.24.0"
-bevy_third_person_camera = "0.1.10"
+bevy = "0.15.1"
+bevy-inspector-egui = "0.28.1"
+bevy_color = "0.15.2"
+bevy_third_person_camera = "0.2.0"

--- a/third_person_beginner/tutorial_6/Cargo.toml
+++ b/third_person_beginner/tutorial_6/Cargo.toml
@@ -8,5 +8,4 @@ edition = "2021"
 [dependencies]
 bevy = "0.15.1"
 bevy-inspector-egui = "0.28.1"
-bevy_color = "0.15.2"
 bevy_third_person_camera = "0.2.0"

--- a/third_person_beginner/tutorial_6/src/camera.rs
+++ b/third_person_beginner/tutorial_6/src/camera.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use bevy_third_person_camera::{camera::Zoom, ThirdPersonCamera};
+use bevy_third_person_camera::{ThirdPersonCamera, Zoom};
 
 pub struct CameraPlugin;
 
@@ -11,10 +11,10 @@ impl Plugin for CameraPlugin {
 
 fn spawn_camera(mut commands: Commands) {
     let camera = (
-        Camera3dBundle {
-            transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
-            ..default()
-        },
+        (
+            Camera3d::default(),
+            Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+        ),
         ThirdPersonCamera {
             zoom: Zoom::new(3.0, 8.0),
             ..default()

--- a/third_person_beginner/tutorial_6/src/player.rs
+++ b/third_person_beginner/tutorial_6/src/player.rs
@@ -18,27 +18,25 @@ struct Speed(f32);
 
 fn spawn_player(mut commands: Commands, assets: Res<AssetServer>) {
     let flashlight = (
-        SpotLightBundle {
-            spot_light: SpotLight {
-                color: Color::rgba(1.0, 1.0, 0.47, 1.0),
+        (
+            SpotLight {
+                color: Color::srgba(1.0, 1.0, 0.47, 1.0),
                 range: 10.0,
                 intensity: 4000.0 * 1000.0,
                 outer_angle: 0.5,
                 inner_angle: 0.4,
                 ..default()
             },
-            transform: Transform::from_xyz(0.0, 0.25, 0.0),
-            ..default()
-        },
+            Transform::from_xyz(0.0, 0.25, 0.0),
+        ),
         Name::new("Flashlight"),
     );
 
     let player = (
-        SceneBundle {
-            scene: assets.load("Player.gltf#Scene0"),
-            transform: Transform::from_xyz(0.0, 0.5, 0.0),
-            ..default()
-        },
+        (
+            SceneRoot(assets.load("Player.gltf#Scene0")),
+            Transform::from_xyz(0.0, 0.5, 0.0),
+        ),
         Player,
         Name::new("Player"),
         ThirdPersonCameraTarget,
@@ -59,7 +57,7 @@ fn player_movement(
     for (mut player_transform, player_speed) in player_q.iter_mut() {
         let cam = match cam_q.get_single() {
             Ok(c) => c,
-            Err(e) => Err(format!("Error retrieving camera: {}", e)).unwrap(),
+            Err(e) => panic!("Error retrieving camera: {}", e),
         };
 
         let mut direction = Vec3::ZERO;
@@ -85,7 +83,7 @@ fn player_movement(
         }
 
         direction.y = 0.0;
-        let movement = direction.normalize_or_zero() * player_speed.0 * time.delta_seconds();
+        let movement = direction.normalize_or_zero() * player_speed.0 * time.delta_secs();
         player_transform.translation += movement;
 
         // rotate player to face direction he is currently moving

--- a/third_person_beginner/tutorial_6/src/world.rs
+++ b/third_person_beginner/tutorial_6/src/world.rs
@@ -1,5 +1,8 @@
 use bevy::prelude::*;
 
+use bevy_color::palettes::css::DARK_GREEN;
+const COLOR_DARK_GREEN: Color = Color::Srgba(DARK_GREEN);
+
 pub struct WorldPlugin;
 
 impl Plugin for WorldPlugin {
@@ -13,26 +16,24 @@ fn spawn_floor(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    let floor = PbrBundle {
-        mesh: meshes.add(Mesh::from(Plane3d::default().mesh().size(15.0, 15.0))),
-        material: materials.add(Color::DARK_GREEN),
-        ..default()
-    };
+    let floor = (
+        Mesh3d(meshes.add(Mesh::from(Plane3d::default().mesh().size(15.0, 15.0)))),
+        MeshMaterial3d(materials.add(COLOR_DARK_GREEN)),
+    );
 
     commands.spawn(floor);
 }
 
 fn spawn_light(mut commands: Commands) {
     let light = (
-        PointLightBundle {
-            point_light: PointLight {
-                color: Color::rgba(0.98, 0.59, 0.0, 1.0),
+        (
+            PointLight {
+                color: Color::srgba(0.98, 0.59, 0.0, 1.0),
                 intensity: 100.0 * 1000.0,
                 ..default()
             },
-            transform: Transform::from_xyz(0.0, 5.0, 0.0),
-            ..default()
-        },
+            Transform::from_xyz(0.0, 5.0, 0.0),
+        ),
         Name::new("PointLight"),
     );
 

--- a/third_person_beginner/tutorial_6/src/world.rs
+++ b/third_person_beginner/tutorial_6/src/world.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
 
-use bevy_color::palettes::css::DARK_GREEN;
-const COLOR_DARK_GREEN: Color = Color::Srgba(DARK_GREEN);
+use bevy::color::palettes::css;
+const COLOR_DARK_GREEN: Color = Color::Srgba(css::DARK_GREEN);
 
 pub struct WorldPlugin;
 

--- a/third_person_beginner/tutorial_7/Cargo.toml
+++ b/third_person_beginner/tutorial_7/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = "0.13.2"
-bevy-inspector-egui = "0.24.0"
-bevy_third_person_camera = "0.1.10"
+bevy = "0.15.1"
+bevy-inspector-egui = "0.28.1"
+bevy_color = "0.15.2"
+bevy_third_person_camera = "0.2.0"

--- a/third_person_beginner/tutorial_7/Cargo.toml
+++ b/third_person_beginner/tutorial_7/Cargo.toml
@@ -8,5 +8,4 @@ edition = "2021"
 [dependencies]
 bevy = "0.15.1"
 bevy-inspector-egui = "0.28.1"
-bevy_color = "0.15.2"
 bevy_third_person_camera = "0.2.0"

--- a/third_person_beginner/tutorial_7/src/camera.rs
+++ b/third_person_beginner/tutorial_7/src/camera.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use bevy_third_person_camera::{camera::Zoom, ThirdPersonCamera};
+use bevy_third_person_camera::{ThirdPersonCamera, Zoom};
 
 pub struct CameraPlugin;
 
@@ -11,10 +11,10 @@ impl Plugin for CameraPlugin {
 
 fn spawn_camera(mut commands: Commands) {
     let camera = (
-        Camera3dBundle {
-            transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
-            ..default()
-        },
+        (
+            Camera3d::default(),
+            Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+        ),
         ThirdPersonCamera {
             zoom: Zoom::new(3.0, 8.0),
             ..default()

--- a/third_person_beginner/tutorial_7/src/player.rs
+++ b/third_person_beginner/tutorial_7/src/player.rs
@@ -18,9 +18,9 @@ struct Speed(f32);
 
 fn spawn_player(mut commands: Commands, assets: Res<AssetServer>) {
     let flashlight = (
-        SpotLightBundle {
-            spot_light: SpotLight {
-                color: Color::rgba(1.0, 1.0, 0.47, 1.0),
+        (
+            SpotLight {
+                color: Color::srgba(1.0, 1.0, 0.47, 1.0),
                 range: 10.0,
                 intensity: 4000.0 * 1000.0,
                 outer_angle: 0.5,
@@ -28,18 +28,16 @@ fn spawn_player(mut commands: Commands, assets: Res<AssetServer>) {
                 shadows_enabled: true,
                 ..default()
             },
-            transform: Transform::from_xyz(0.0, 0.25, -0.3),
-            ..default()
-        },
+            Transform::from_xyz(0.0, 0.25, -0.3),
+        ),
         Name::new("Flashlight"),
     );
 
     let player = (
-        SceneBundle {
-            scene: assets.load("Player.gltf#Scene0"),
-            transform: Transform::from_xyz(0.0, 0.5, 0.0),
-            ..default()
-        },
+        (
+            SceneRoot(assets.load("Player.gltf#Scene0")),
+            Transform::from_xyz(0.0, 0.5, 0.0),
+        ),
         Player,
         Name::new("Player"),
         ThirdPersonCameraTarget,
@@ -60,7 +58,7 @@ fn player_movement(
     for (mut player_transform, player_speed) in player_q.iter_mut() {
         let cam = match cam_q.get_single() {
             Ok(c) => c,
-            Err(e) => Err(format!("Error retrieving camera: {}", e)).unwrap(),
+            Err(e) => panic!("Error retrieving camera: {}", e),
         };
 
         let mut direction = Vec3::ZERO;
@@ -86,7 +84,7 @@ fn player_movement(
         }
 
         direction.y = 0.0;
-        let movement = direction.normalize_or_zero() * player_speed.0 * time.delta_seconds();
+        let movement = direction.normalize_or_zero() * player_speed.0 * time.delta_secs();
         player_transform.translation += movement;
 
         // rotate player to face direction he is currently moving

--- a/third_person_beginner/tutorial_7/src/world.rs
+++ b/third_person_beginner/tutorial_7/src/world.rs
@@ -1,5 +1,10 @@
 use bevy::prelude::*;
 
+use bevy_color::palettes::css::{DARK_GREEN, MIDNIGHT_BLUE, RED};
+const COLOR_DARK_GREEN: Color = Color::Srgba(DARK_GREEN);
+const COLOR_RED: Color = Color::Srgba(RED);
+const COLOR_MIDNIGHT_BLUE: Color = Color::Srgba(MIDNIGHT_BLUE);
+
 pub struct WorldPlugin;
 
 impl Plugin for WorldPlugin {
@@ -13,26 +18,24 @@ fn spawn_floor(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    let floor = PbrBundle {
-        mesh: meshes.add(Mesh::from(Plane3d::default().mesh().size(15.0, 15.0))),
-        material: materials.add(Color::DARK_GREEN),
-        ..default()
-    };
+    let floor = (
+        Mesh3d(meshes.add(Mesh::from(Plane3d::default().mesh().size(15.0, 15.0)))),
+        MeshMaterial3d(materials.add(COLOR_DARK_GREEN)),
+    );
 
     commands.spawn(floor);
 }
 
 fn spawn_light(mut commands: Commands) {
     let light = (
-        PointLightBundle {
-            point_light: PointLight {
-                color: Color::rgba(0.98, 0.59, 0.0, 1.0),
+        (
+            PointLight {
+                color: Color::srgba(0.98, 0.59, 0.0, 1.0),
                 intensity: 100.0 * 1000.0,
                 ..default()
             },
-            transform: Transform::from_xyz(0.0, 5.0, 0.0),
-            ..default()
-        },
+            Transform::from_xyz(0.0, 5.0, 0.0),
+        ),
         Name::new("PointLight"),
     );
 
@@ -45,27 +48,26 @@ fn spawn_objects(
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
     let mut create_obj =
-        |size: f32, color: Color, name: String, xyz: (f32, f32, f32)| -> (PbrBundle, Name) {
+        |size: f32, color: Color, name: String, xyz: (f32, f32, f32)| -> (_, Name) {
             (
-                PbrBundle {
-                    mesh: meshes.add(Cuboid::new(size, size, size)),
-                    material: materials.add(color),
-                    transform: Transform::from_xyz(xyz.0, xyz.1, xyz.2),
-                    ..default()
-                },
+                (
+                    Mesh3d(meshes.add(Cuboid::new(size, size, size))),
+                    MeshMaterial3d(materials.add(color)),
+                    Transform::from_xyz(xyz.0, xyz.1, xyz.2),
+                ),
                 Name::new(name),
             )
         };
 
     commands.spawn(create_obj(
         3.0,
-        Color::RED,
+        COLOR_RED,
         "Red Cube".to_string(),
         (-4.5, 1.5, -4.5),
     ));
     commands.spawn(create_obj(
         2.0,
-        Color::MIDNIGHT_BLUE,
+        COLOR_MIDNIGHT_BLUE,
         "Blue Cube".to_string(),
         (5.3, 1.0, 5.7),
     ));

--- a/third_person_beginner/tutorial_7/src/world.rs
+++ b/third_person_beginner/tutorial_7/src/world.rs
@@ -1,9 +1,9 @@
 use bevy::prelude::*;
 
-use bevy_color::palettes::css::{DARK_GREEN, MIDNIGHT_BLUE, RED};
-const COLOR_DARK_GREEN: Color = Color::Srgba(DARK_GREEN);
-const COLOR_RED: Color = Color::Srgba(RED);
-const COLOR_MIDNIGHT_BLUE: Color = Color::Srgba(MIDNIGHT_BLUE);
+use bevy::color::palettes::css;
+const COLOR_DARK_GREEN: Color = Color::Srgba(css::DARK_GREEN);
+const COLOR_RED: Color = Color::Srgba(css::RED);
+const COLOR_MIDNIGHT_BLUE: Color = Color::Srgba(css::MIDNIGHT_BLUE);
 
 pub struct WorldPlugin;
 

--- a/third_person_beginner/tutorial_8/Cargo.toml
+++ b/third_person_beginner/tutorial_8/Cargo.toml
@@ -8,6 +8,5 @@ edition = "2021"
 [dependencies]
 bevy = "0.15.1"
 bevy-inspector-egui = "0.28.1"
-bevy_color = "0.15.2"
 bevy_rapier3d = "0.28.0"
 bevy_third_person_camera = "0.2.0"

--- a/third_person_beginner/tutorial_8/Cargo.toml
+++ b/third_person_beginner/tutorial_8/Cargo.toml
@@ -6,7 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = "0.13.2"
-bevy-inspector-egui = "0.24.0"
-bevy_rapier3d = "0.26.0"
-bevy_third_person_camera = "0.1.10"
+bevy = "0.15.1"
+bevy-inspector-egui = "0.28.1"
+bevy_color = "0.15.2"
+bevy_rapier3d = "0.28.0"
+bevy_third_person_camera = "0.2.0"

--- a/third_person_beginner/tutorial_8/src/camera.rs
+++ b/third_person_beginner/tutorial_8/src/camera.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use bevy_third_person_camera::{camera::Zoom, ThirdPersonCamera};
+use bevy_third_person_camera::{ThirdPersonCamera, Zoom};
 
 pub struct CameraPlugin;
 
@@ -11,10 +11,10 @@ impl Plugin for CameraPlugin {
 
 fn spawn_camera(mut commands: Commands) {
     let camera = (
-        Camera3dBundle {
-            transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
-            ..default()
-        },
+        (
+            Camera3d::default(),
+            Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+        ),
         ThirdPersonCamera {
             zoom: Zoom::new(3.0, 8.0),
             ..default()

--- a/third_person_beginner/tutorial_8/src/world.rs
+++ b/third_person_beginner/tutorial_8/src/world.rs
@@ -1,6 +1,11 @@
 use bevy::prelude::*;
 use bevy_rapier3d::prelude::*;
 
+use bevy_color::palettes::css::{DARK_GREEN, MIDNIGHT_BLUE, RED};
+const COLOR_DARK_GREEN: Color = Color::Srgba(DARK_GREEN);
+const COLOR_RED: Color = Color::Srgba(RED);
+const COLOR_MIDNIGHT_BLUE: Color = Color::Srgba(MIDNIGHT_BLUE);
+
 pub struct WorldPlugin;
 
 impl Plugin for WorldPlugin {
@@ -15,11 +20,10 @@ fn spawn_floor(
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
     let floor = (
-        PbrBundle {
-            mesh: meshes.add(Mesh::from(Plane3d::default().mesh().size(15.0, 15.0))),
-            material: materials.add(Color::DARK_GREEN),
-            ..default()
-        },
+        (
+            Mesh3d(meshes.add(Mesh::from(Plane3d::default().mesh().size(15.0, 15.0)))),
+            MeshMaterial3d(materials.add(COLOR_DARK_GREEN)),
+        ),
         Collider::cuboid(7.5, 0.0, 7.5),
     );
 
@@ -28,15 +32,14 @@ fn spawn_floor(
 
 fn spawn_light(mut commands: Commands) {
     let light = (
-        PointLightBundle {
-            point_light: PointLight {
-                color: Color::rgba(0.98, 0.59, 0.0, 1.0),
+        (
+            PointLight {
+                color: Color::srgba(0.98, 0.59, 0.0, 1.0),
                 intensity: 100.0 * 1000.0,
                 ..default()
             },
-            transform: Transform::from_xyz(0.0, 5.0, 0.0),
-            ..default()
-        },
+            Transform::from_xyz(0.0, 5.0, 0.0),
+        ),
         Name::new("PointLight"),
     );
 
@@ -52,14 +55,13 @@ fn spawn_objects(
                           color: Color,
                           name: String,
                           xyz: (f32, f32, f32)|
-     -> (PbrBundle, Name, Collider, RigidBody) {
+     -> (_, Name, Collider, RigidBody) {
         (
-            PbrBundle {
-                mesh: meshes.add(Cuboid::new(size, size, size)),
-                material: materials.add(color),
-                transform: Transform::from_xyz(xyz.0, xyz.1, xyz.2),
-                ..default()
-            },
+            (
+                Mesh3d(meshes.add(Cuboid::new(size, size, size))),
+                MeshMaterial3d(materials.add(color)),
+                Transform::from_xyz(xyz.0, xyz.1, xyz.2),
+            ),
             Name::new(name),
             Collider::cuboid(size / 2.0, size / 2.0, size / 2.0),
             RigidBody::Dynamic,
@@ -68,13 +70,13 @@ fn spawn_objects(
 
     commands.spawn(create_obj(
         3.0,
-        Color::RED,
+        COLOR_RED,
         "Red Cube".to_string(),
         (-4.5, 1.5, -4.5),
     ));
     commands.spawn(create_obj(
         2.0,
-        Color::MIDNIGHT_BLUE,
+        COLOR_MIDNIGHT_BLUE,
         "Blue Cube".to_string(),
         (5.3, 1.0, 5.7),
     ));

--- a/third_person_beginner/tutorial_8/src/world.rs
+++ b/third_person_beginner/tutorial_8/src/world.rs
@@ -1,10 +1,10 @@
 use bevy::prelude::*;
 use bevy_rapier3d::prelude::*;
 
-use bevy_color::palettes::css::{DARK_GREEN, MIDNIGHT_BLUE, RED};
-const COLOR_DARK_GREEN: Color = Color::Srgba(DARK_GREEN);
-const COLOR_RED: Color = Color::Srgba(RED);
-const COLOR_MIDNIGHT_BLUE: Color = Color::Srgba(MIDNIGHT_BLUE);
+use bevy::color::palettes::css;
+const COLOR_DARK_GREEN: Color = Color::Srgba(css::DARK_GREEN);
+const COLOR_RED: Color = Color::Srgba(css::RED);
+const COLOR_MIDNIGHT_BLUE: Color = Color::Srgba(css::MIDNIGHT_BLUE);
 
 pub struct WorldPlugin;
 


### PR DESCRIPTION
This PR updates the examples to be compatible with the latest Bevy version, `0.15.1`.

Notable differences:
- Update code to use new Bevy API where breaking changes occurred between `0.13.2` -> `0.15.1`
- Replace deprecated structs with the new tuple syntax. [example from the Bevy docs](https://docs.rs/bevy/0.15.1/bevy/prelude/struct.Mesh3d.html)
- Use equivalent color constants from `bevy::palettes::css` instead of  those in `bevy::render::color`, which were removed
- Update the other dependencies, including `bevy-inspector-egui`, where possible